### PR TITLE
Socket_Cam problem

### DIFF
--- a/socket_server_cam.py
+++ b/socket_server_cam.py
@@ -37,7 +37,7 @@ async def Operate_soc(websocket, path):
     cap.release
     cv2.destroyAllWindows()
     
-#starting the server
+#starting the server 
 #replace with your ipaddress and port num
 start_server = websockets.serve(Operate_soc, "192.168.29.228", 4000)
 


### PR DESCRIPTION
The images captured from camera are stored and retrieved by encoder which leads to a shaking picture of cam

Instead of storing the images,the frames should send directly to the encoder
Solve the problem if you can